### PR TITLE
Integrated DataManager; factored config loading out of main framework…

### DIFF
--- a/honeypot/__init__.py
+++ b/honeypot/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'jessenelson'

--- a/honeypot/src/__init__.py
+++ b/honeypot/src/__init__.py
@@ -1,1 +1,1 @@
-__author__ = 'jessenelson'
+

--- a/honeypot/src/main/__init__.py
+++ b/honeypot/src/main/__init__.py
@@ -1,1 +1,1 @@
-__author__ = 'jessenelson'
+

--- a/honeypot/src/main/framework/__init__.py
+++ b/honeypot/src/main/framework/__init__.py
@@ -1,2 +1,1 @@
-import main.framework.frmwork
-import main.framework.networklistener
+

--- a/honeypot/src/main/framework/globalconfig.py
+++ b/honeypot/src/main/framework/globalconfig.py
@@ -1,0 +1,38 @@
+__author__ = 'Jesse Nelson <jnels1242012@gmail.com>, ' \
+             'Randy Sorensen <sorensra@msudenver.edu>'
+
+import configparser
+import os
+
+
+class GlobalConfig:
+    def __init__(self, cfg_path):
+        self.cfg_path = cfg_path
+        self.plugin_config = configparser.ConfigParser()
+        self.config_dictionary = {}
+
+    # ToDo: Dont use eval!
+    def create_config_object(self, plugin):
+        port = int(self.plugin_config.get(plugin, 'port'))
+        table_name = self.plugin_config.get(plugin, 'table')
+        enabled = self.plugin_config.get(plugin, 'enabled')
+        column_defs = eval(self.plugin_config.get(plugin, 'tableColumns'))
+        module = self.plugin_config.get(plugin, 'module')
+
+        config_object = {
+            'port': port,
+            'table': table_name,
+            'enabled': enabled,
+            'tableColumns': column_defs,
+            'module': module
+        }
+
+        return (port, module, config_object)
+
+    def read_config(self, plugin_cfg):
+        plugin_config_file = os.path.dirname(
+            os.path.abspath(__file__)) + self.cfg_path
+        self.plugin_config.read(plugin_config_file)
+
+    def get_sections(self):
+        return self.plugin_config.sections()

--- a/honeypot/src/main/framework/tests/framework_test.py
+++ b/honeypot/src/main/framework/tests/framework_test.py
@@ -2,10 +2,20 @@ __author__ = 'Jesse Nelson <jnels1242012@gmail.com>, ' \
              'Randy Sorensen <sorensra@msudenver.edu>'
 
 import unittest
-from framework.frmwork import Framework
+from framework.frmwork import Framework, main
 from unittest.mock import patch
 
 config_path = '/tests/testConfig.cfg'
+
+
+def make_mock_config(port, module):
+    return {
+        'port': port,
+        'module': module,
+        'table': 'test',
+        'enabled': 'Yes',
+        'tableColumns': [[1, 'INTEGER', 'someNumber'], [2, 'TEXT', 'someText']]
+    }
 
 
 class FrameworkTest(unittest.TestCase):
@@ -15,14 +25,9 @@ class FrameworkTest(unittest.TestCase):
     @patch('networklistener.NetworkListener.start')
     def test_plugins_enabled(self, test_patch):
         framework = Framework(config_path)
+        framework.start()
         expected = {
-            8082: {
-                'port': 8082,
-                'module': 'HTTPPlugin',
-                'table': 'test',
-                'enabled': 'Yes',
-                'tableColumns': [[1, 'INTEGER', 'someNumber'], [2, 'TEXT', 'someText']]
-            }
+            8082: make_mock_config(8082, 'HTTPPlugin')
         }
         self.assertEqual(expected, framework.config_dictionary)
         self.assertTrue(test_patch.called)
@@ -31,6 +36,7 @@ class FrameworkTest(unittest.TestCase):
     @patch('networklistener.NetworkListener.start')
     def test_plugins_disabled(self, test_patch):
         framework = Framework(config_path)
+        framework.start()
         self.assertTrue(8083 not in framework.config_dictionary)
         self.assertTrue(8082 in framework.config_dictionary)
         self.assertEquals(1, test_patch.call_count)
@@ -38,21 +44,22 @@ class FrameworkTest(unittest.TestCase):
     @patch('networklistener.NetworkListener.start')
     def test_get_config(self, test_patch):
         framework = Framework(config_path)
-        expected = {
-            'port': 8082,
-            'module': 'HTTPPlugin',
-            'table': 'test',
-            'enabled': 'Yes',
-            'tableColumns': [[1, 'INTEGER', 'someNumber'], [2, 'TEXT', 'someText']]
-        }
+        framework.start()
+        expected = make_mock_config(8082, 'HTTPPlugin')
         self.assertEqual(expected, framework.get_config(8082))
 
     @patch('networklistener.NetworkListener.start')
     @patch('plugins.HTTPPlugin.HTTPPlugin.start')
     def test_spawn(self, net_patch, plugin_patch):
         framework = Framework(config_path)
+        framework.start()
         framework.spawn(None, {'port': 8082})
         self.assertTrue(plugin_patch.called)
+
+    @patch.object(Framework, 'start')
+    def test_main(self, mock_framework_start):
+        main()
+        self.assertTrue(mock_framework_start.called)
 
     def tearDown(self):
         pass

--- a/honeypot/src/main/framework/tests/networklistener_test.py
+++ b/honeypot/src/main/framework/tests/networklistener_test.py
@@ -7,6 +7,8 @@ from networklistener import NetworkListener
 from frmwork import Framework
 from unittest.mock import patch
 
+config_path = '/tests/testConfig.cfg'
+
 
 def make_mock_config(port, module):
     return {
@@ -23,14 +25,14 @@ class NetworkListenerTest(unittest.TestCase):
         pass
 
     @patch('networklistener.NetworkListener.start_listening')
-    def test_plugins_enabled(self, test_start_listening):
+    def test_plugins_enabled(self, mock_start_listening):
         mock_config = make_mock_config(8082, 'HTTPPlugin')
         listener = NetworkListener(mock_config, None)
         listener.start()
         while listener.connection_count == 0:
             pass
         listener.stop()
-        self.assertTrue(test_start_listening.called)
+        self.assertTrue(mock_start_listening.called)
 
     def test_connection_count(self):
         mock_config = make_mock_config(8082, 'HTTPPlugin')
@@ -40,20 +42,19 @@ class NetworkListenerTest(unittest.TestCase):
         self.assertEqual(5, listener.connection_count)
 
     @patch.object(Framework, 'spawn')
-    def test_start_listening(self, mock_spawn):
+    def test_start_listening(self, mock_framework):
         mock_config = make_mock_config(8082, 'HTTPPlugin')
         with patch('networklistener.socket.socket.accept') as mock_accept:
             mock_accept.return_value = (socket.socket(), '192.168.1.1')
-            listener = NetworkListener(mock_config, mock_spawn)
+            listener = NetworkListener(mock_config, mock_framework)
             listener.start_listening(socket.socket())
         self.assertTrue(mock_accept.called)
-        self.assertTrue(mock_spawn.spawn.called)
+        self.assertTrue(mock_framework.spawn.called)
 
     def test_start_listening_exception(self):
         mock_config = make_mock_config(8082, 'HTTPPlugin')
         listener = NetworkListener(mock_config, None)
         self.assertRaises(Exception, listener.start_listening, None)
-
 
     def tearDown(self):
         pass

--- a/honeypot/src/main/plugins/BasePlugin.py
+++ b/honeypot/src/main/plugins/BasePlugin.py
@@ -4,9 +4,10 @@ from threading import Thread
 
 
 class BasePlugin(Thread):
-    def __init__(self, socket):
+    def __init__(self, socket, framework):
         Thread.__init__(self)
         self._skt = socket
+        self._framework = framework
         pass
 
     def run(self):

--- a/honeypot/src/main/plugins/HTTPPlugin.py
+++ b/honeypot/src/main/plugins/HTTPPlugin.py
@@ -4,8 +4,8 @@ from plugins.BasePlugin import BasePlugin
 
 
 class HTTPPlugin(BasePlugin):
-    def __init__(self, socket):
-        BasePlugin.__init__(self, socket)
+    def __init__(self, socket, framework):
+        BasePlugin.__init__(self, socket, framework)
         print('Spawned team!')
 
     def do_track(self):


### PR DESCRIPTION
… class.
- Added a class "GlobalConfig" which handles loading and parsing of the configuration file.
- Integrated DataManager class with the framework.
- Added docstrings to the public API methods in the framework.
- Minor cleanups here & there in framework code and in framework unit test.

Notes:
- Currently there is no way to stop the consumer thread in the DataManager class. This shouldn't be difficult to fix, however the unit tests must be manually stopped. We ran into this problem with the NetworkListener thread as well, and perhaps a similar fix would work for DataManager.
- It would be nice if we could write a unit test that demonstrates Matt's "Connection refused" exception - to replicate this, start the framework, and run "nmap -v -A localhost -p 8082" and note the exception generated by the framework. I believe it simply connects to the listening socket and then closes it before recv() is called by the plugin.
- Something I was looking into for "bubbling" exceptions up from threads and through the framework: https://stackoverflow.com/questions/2829329/catch-a-threads-exception-in-the-caller-thread-in-python
- Still need to write a unit test for Framework.insert_data(); this is all that's preventing 100% code coverage in the framework.

@jnels124 @howard-roark @benphillips989 
