### PR TITLE
changed order, now non-plugin tables are added first in db_init.

### DIFF
--- a/database/DB_Init.py
+++ b/database/DB_Init.py
@@ -8,11 +8,11 @@ __author__ = 'Ben Phillips'
 
 '''calls methods needed to create the database'''
 def create_default_database(global_config_instance):
-
     create_db_dir(global_config_instance)
     create_db(global_config_instance)
-    update_schema(global_config_instance)
     Table_Init.run_db_scripts(global_config_instance)
+    update_schema(global_config_instance)
+
 '''creates the database directory if it does not exist'''
 def create_db_dir(global_config_instance):
     """if database directory does not exist create it"""

--- a/database/Table_Init.py
+++ b/database/Table_Init.py
@@ -118,6 +118,10 @@ def change_table_structure(name,config_column_list,db_column_list,global_config_
 def delete_table(name,global_config_instance):
     connection = sqlite3.connect(global_config_instance.get_db_dir() + '/honeyDB.sqlite')
     cursor = connection.cursor()
+    '''if you are deleting a table due to changing the configuration of the columns lets remove any sessions from the
+       sessions table referencing the old table'''
+    if(cursor.execute("SELECT count(*) FROM sqlite_master WHERE type='table' and name='" + name + "_delme';").fetchall()[0][0] > 0):
+        cursor.execute("DELETE from sessions where table_name = '" + name + "';")
     cursor.execute("DROP TABLE IF EXISTS " + name + "_delme;")
     cursor.close
 


### PR DESCRIPTION
added functionality to remove rows from session table when plugin
table schemas are altered. Because all of the data in the plugin table
is destroyed when changing the layout we do not want orphaned records
in the session table.
