### PR TITLE
added eventDateTime index to all plugin tables

### DIFF
--- a/database/Table_Init.py
+++ b/database/Table_Init.py
@@ -27,7 +27,12 @@ def create_table(name, global_config):
     cursor.execute('CREATE TABLE ' + name + '(' + default_column_def + ')')
     connection.close()
 
-
+def create_index(cfg_tables, global_config):
+    connection = sqlite3.connect(global_config['Database']['path'])
+    cursor = connection.cursor()
+    for name in cfg_tables:
+        cursor.execute('CREATE INDEX IF NOT EXISTS DT_IDX_' + name + ' ON ' + name + ' (eventDateTime)')
+    connection.close()
 
 def add_columns(name, column_list, global_config):
     """
@@ -115,5 +120,9 @@ def delete_table(name, global_config):
         cursor.execute(
             "DELETE FROM sessions " +
             "WHERE table_name = '" + name + "';")
+    # drop index first
+    cursor.execute("DROP INDEX IF EXISTS DT_IDX_" + name)
+    # drop table
     cursor.execute("DROP TABLE IF EXISTS " + name + "_delme;")
+
     cursor.close()

--- a/database/database.py
+++ b/database/database.py
@@ -25,7 +25,8 @@ class Database:
         run_db_scripts(self.global_config)
 
         self.update_schema()
-    
+
+
     def create_db_dir(self):
         """
         Creates the database directory if it doesn't already exist.
@@ -72,6 +73,9 @@ class Database:
         # definitions.
         DataValidator().update_tables_and_schema()
         self.update_table_structure()
+        #create indexes on plugin tables if they do not exist
+        Table_Init.create_index(cfg_tables,self.global_config)
+
 
     def create_non_exist_tables(self, table_diff):
         """


### PR DESCRIPTION
added eventDateTime index to all plugin tables, the indexes get deleted when the table gets deleted on column renames and recreated along with the new table. Should speed up queries where date is involved.
